### PR TITLE
参数顺序错误

### DIFF
--- a/command/tar.md
+++ b/command/tar.md
@@ -356,7 +356,7 @@ tar -tf all.tar
 ```
 
 ```shell
-tar -cfv archive.tar foo bar  # 从文件foo和bar创建archive.tar。
+tar -cvf archive.tar foo bar  # 从文件foo和bar创建archive.tar。
 tar -tvf archive.tar         # 详细列出archive.tar中的所有文件。
 tar -xf archive.tar          # 从archive.tar提取所有文件。
 ```


### PR DESCRIPTION
正如文档前文提到：
> -f: 使用档案名字，切记，这个参数是最后一个参数，后面只能接档案名。