### PR TITLE
更新`IPCS`命令

### DIFF
--- a/command/ipcs.md
+++ b/command/ipcs.md
@@ -18,30 +18,30 @@ ipcs(选项)
 #### 资源选项
 
 ```shell
--a, --all 				显示全部(默认值)
--q, --queues 			消息队列
--m, --shmems 			共享内存
--s, --semaphores 	信号量
+-a, --all         显示全部(默认值)
+-q, --queues      消息队列
+-m, --shmems      共享内存
+-s, --semaphores  信号量
 ```
 
 #### 输出选项
 
 ```shell
--t, --time 				显示最后一次操作时间
--p, --pid 				显示创建者和最后一次操作者的PID
--c, --creator 		显示创建者和拥有者的 userid, groupid
--l, --limits 			显示对资源的限制
--u, --summary			显示当前状态摘要
---human 					以友好的方式显示大小(eg: 500K)
--b, --bytes      	以字节为单位显示大小(仅影响`-l`选项)
+-t, --time        显示最后一次操作时间
+-p, --pid         显示创建者和最后一次操作者的PID
+-c, --creator     显示创建者和拥有者的 userid, groupid
+-l, --limits      显示对资源的限制
+-u, --summary     显示当前状态摘要
+--human           以友好的方式显示大小(eg: 500K)
+-b, --bytes       以字节为单位显示大小(仅影响`-l`选项)
 ```
 
 #### 通用选项
 
 ```shell
--i, --id <id>  	显示指定ID的资源
--h, --help     	显示帮助文档并退出
--V, --version  	显示版本信息并退出
+-i, --id <id>   显示指定ID的资源
+-h, --help      显示帮助文档并退出
+-V, --version   显示版本信息并退出
 ```
 
 ###  实例


### PR DESCRIPTION
刚才提交的内容, 使用了`tab`进行对其, 但是发现在 [页面显示](https://wangchujiang.com/linux-command/c/ipcs.html) 中, `tab`并没有对其, 故改为了空格对齐.