### PR TITLE
去掉 awk 脚本放在双引号中的部分

### DIFF
--- a/command/awk.md
+++ b/command/awk.md
@@ -51,11 +51,10 @@ awk脚本是由模式和操作组成的。
 awk 'BEGIN{ print "start" } pattern{ commands } END{ print "end" }' file
 ```
 
-一个awk脚本通常由：BEGIN语句块、能够使用模式匹配的通用语句块、END语句块3部分组成，这三个部分是可选的。任意一个部分都可以不出现在脚本中，脚本通常是被 **单引号** 或 **双引号** 中，例如：
+一个awk脚本通常由：BEGIN语句块、能够使用模式匹配的通用语句块、END语句块3部分组成，这三个部分是可选的。任意一个部分都可以不出现在脚本中，脚本通常是被 **单引号** 中，例如：
 
 ```shell
 awk 'BEGIN{ i=0 } { i++ } END{ print i }' filename
-awk "BEGIN{ i=0 } { i++ } END{ print i }" filename
 ```
 
 ###  awk的工作原理 


### PR DESCRIPTION
因为 shell 会对双引号中的变量替换, 比如 $0 在执行 awk 前被展开, 所以一般会使用单引号