### PR TITLE
fix: fix the typo and add some examples

### DIFF
--- a/command/tar.md
+++ b/command/tar.md
@@ -469,7 +469,7 @@ tar -jcvf log.tar.bz2 log2012.log  打包后，以 bzip2 压缩
 
 **解压目录**
 
-去掉第一层目录结构，要出除第二层，--strip-components 2
+去掉第一层目录结构，取出第二层（即剥离第一个路径），--strip-components 2
 
 ```shell
 tar -xvf portal-web-v2.0.0.tar --strip-components 1  -C 指定目录

--- a/command/tar.md
+++ b/command/tar.md
@@ -469,10 +469,17 @@ tar -jcvf log.tar.bz2 log2012.log  打包后，以 bzip2 压缩
 
 **解压目录**
 
-去掉第一层目录结构，取出第二层（即剥离第一个路径），--strip-components 2
+参数--strip-components NUMBER，在提取时从文件名中删除NUMBER个前导组件，如要去除前二层，参数为--strip-components 2
 
 ```shell
 tar -xvf portal-web-v2.0.0.tar --strip-components 1  -C 指定目录
+
+示例
+tar -xvf xxx.tar.gz -C /usr/src/a
+/usr/src/a/xxxxx/src/opp/b.txt
+
+tar -xvf xxx.tar.gz -strip-components=1 -C /usr/src/a
+/usr/src/a/src/opp/b.txt
 ```
 
 **查阅上述tar包内有哪些文件** ：


### PR DESCRIPTION
- `去掉第一层目录结构，要出除第二层，--strip-components 2` 此句意义不明，看起来`出除`二字应该像是`去除`，而且又与`去掉第一层目录结构`的语义上感觉没啥关联。
- 我将其修改为`参数--strip-components NUMBER，在提取时从文件名中删除NUMBER个前导路径，如要去除前二个，参数可以设为--strip-components 2`，并添加适当的examples帮助理解