### PR TITLE
fixup command mistake

### DIFF
--- a/command/strings.md
+++ b/command/strings.md
@@ -38,7 +38,7 @@ strings /bin/ls
 列出ls中所有的ASCII文本：
 
 ```shell
-cat /bin/ls strings
+cat /bin/ls | strings
 ```
 
 查找ls中包含libc的字符串，不区分大小写：


### PR DESCRIPTION
`实例` 中的第二个例子的命令错误，缺少管道符 `|`