### PR TITLE
修改 nmap.md 中的非法网站为官方测试网站

### DIFF
--- a/command/nmap.md
+++ b/command/nmap.md
@@ -54,20 +54,29 @@ ip地址：指定待扫描报文中的TCP地址。
 yum install nmap
 ```
 
- **使用nmap扫描www.jsdig.com的开放端口** 
+ **使用nmap扫描scanme.nmap.org的开放端口** 
 
 ```shell
-[root@localhost ~]# nmap www.jsdig.com
+[root@localhost ~]# nmap scanme.nmap.org
 
-Starting Nmap 4.11 ( http://www.insecure.org/nmap/ ) at 2013-12-28 00:06 CST
-Interesting ports on 100-42-212-8.static.webnx.com (100.42.212.8):
-Not shown: 1678 filtered ports
-PORT   STATE service
-22/tcp open  ssh
-80/tcp open  http
+Starting Nmap 7.92 ( https://nmap.org ) at 2025-08-06 15:22 CST
+Nmap scan report for scanme.nmap.org (45.33.32.156)
+Host is up (0.37s latency).
+Not shown: 991 closed tcp ports (reset)
+PORT      STATE    SERVICE
+22/tcp    open     ssh
+80/tcp    open     http
+135/tcp   filtered msrpc
+139/tcp   filtered netbios-ssn
+445/tcp   filtered microsoft-ds
+593/tcp   filtered http-rpc-epmap
+4444/tcp  filtered krb524
+9929/tcp  open     nping-echo
+31337/tcp open     Elite
 
-Nmap finished: 1 IP address (1 host up) scanned in 45.870 seconds
+Nmap done: 1 IP address (1 host up) scanned in 60.36 seconds
 ```
+
 
 
 


### PR DESCRIPTION
替换原实例网址，该网址已被污染为非法网站。
替换后的网址scanme.nmap.org为nmap官方测试使用的网址